### PR TITLE
Use chart.googleapis.com instead of google.com

### DIFF
--- a/lib/GoogleAuthenticator.php
+++ b/lib/GoogleAuthenticator.php
@@ -99,7 +99,7 @@ class GoogleAuthenticator
      */
     public function getUrl($user, $hostname, $secret)
     {
-        $encoder = "https://www.google.com/chart?chs=200x200&chld=M|0&cht=qr&chl=";
+        $encoder = "https://chart.googleapis.com/chart?chs=200x200&chld=M|0&cht=qr&chl=";
         $encoderURL = sprintf("%sotpauth://totp/%s@%s%%3Fsecret%%3D%s", $encoder, $user, $hostname, $secret);
 
         return $encoderURL;

--- a/tests/GoogleAuthenticatorTest.php
+++ b/tests/GoogleAuthenticatorTest.php
@@ -34,7 +34,7 @@ class HandlerTest extends \PHPUnit_Framework_TestCase
     {
         $url = $this->helper->getUrl('foo', 'foobar.org', '3DHTQX4GCRKHGS55CJ');
 
-        $expected = "https://www.google.com/chart?chs=200x200&chld=M|0&cht=qr&chl=otpauth://totp/foo@foobar.org%3Fsecret%3D3DHTQX4GCRKHGS55CJ";
+        $expected = "https://chart.googleapis.com/chart?chs=200x200&chld=M|0&cht=qr&chl=otpauth://totp/foo@foobar.org%3Fsecret%3D3DHTQX4GCRKHGS55CJ";
 
         $this->assertEquals($expected, $url);
     }


### PR DESCRIPTION
I kept getting 400 errors (there are quite a few reports online of this happening with google.com).

Example:
http://stackoverflow.com/questions/17071368/400-bad-request-when-attempting-to-insert-qr-code-image-for-google-authenticator
