### PR TITLE
Use issuer instead of hostname in getUrl

### DIFF
--- a/lib/GoogleAuthenticator.php
+++ b/lib/GoogleAuthenticator.php
@@ -92,17 +92,17 @@ class GoogleAuthenticator
     }
 
     /**
-     * @param  string $user
-     * @param  string $hostname
+     * @param  string $label
+     * @param  string $issuer
      * @param  string $secret
      * @return string
      */
-    public function getUrl($user, $hostname, $secret)
+    public function getUrl($label, $issuer, $secret)
     {
         $encoder = "https://chart.googleapis.com/chart?chs=200x200&chld=M|0&cht=qr&chl=";
-        $encoderURL = sprintf("%sotpauth://totp/%s@%s%%3Fsecret%%3D%s", $encoder, $user, $hostname, $secret);
+        $url = sprintf("otpauth://totp/%s?issuer=%s&secret=%s", $label, $issuer, $secret);
 
-        return $encoderURL;
+        return $encoder . urlencode($url);
     }
 
     /**

--- a/tests/GoogleAuthenticatorTest.php
+++ b/tests/GoogleAuthenticatorTest.php
@@ -34,7 +34,7 @@ class HandlerTest extends \PHPUnit_Framework_TestCase
     {
         $url = $this->helper->getUrl('foo', 'foobar.org', '3DHTQX4GCRKHGS55CJ');
 
-        $expected = "https://chart.googleapis.com/chart?chs=200x200&chld=M|0&cht=qr&chl=otpauth://totp/foo@foobar.org%3Fsecret%3D3DHTQX4GCRKHGS55CJ";
+        $expected = "https://chart.googleapis.com/chart?chs=200x200&chld=M|0&cht=qr&chl=otpauth%3A%2F%2Ftotp%2Ffoo%3Fissuer%3Dfoobar.org%26secret%3D3DHTQX4GCRKHGS55CJ";
 
         $this->assertEquals($expected, $url);
     }


### PR DESCRIPTION
An issuer is STRONGLY RECOMMENDED: https://github.com/google/google-authenticator/wiki/Key-Uri-Format
The label can be an email but doesn't have to be. The hostname was a bit unexpected, and it wasn't possible to use an identifier.

This could be considered as a breaking change, but I changed the hostname to issuer. So instead of having the label username@hostname.com it will now by username, with hostname.com as issuer. That should only effect the way the app shows the token (I think)

If you were to allow a more breaking change, the issuer could be made optional as the last argument, although it is stated as strongly recommended.

(An alternative would be #5 but that doesn't allow for labels other then emails)