### PR TITLE
Replaced insecure `rand` wih `random_bytes`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
 
     ],
     "require": {
-        "php": "^5.3 || ^7.0"
+        "php": "^5.3 || ^7.0",
+        "paragonie/random_compat": "^2.0"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "~2.7|~3.0",

--- a/lib/GoogleAuthenticator.php
+++ b/lib/GoogleAuthenticator.php
@@ -108,11 +108,7 @@ class GoogleAuthenticator
      */
     public function generateSecret()
     {
-        $secret = '';
-        for ($i = 1; $i <= $this->secretLength; ++$i) {
-            $c = rand(0, 255);
-            $secret .= pack('c', $c);
-        }
+        $secret = random_bytes($this->secretLength);
 
         $base32 = new FixedBitNotation(5, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567', true, true);
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/GoogleAuthenticator/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it's a backward compatible change

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

It replaces a currently used `rand` with a cryptographically strong `random_bytes`

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Security
- now generation of the secret is cryptographically strong.
```


## Subject

<!-- Describe your Pull Request content here -->

