### PR TITLE
Drop old versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "paragonie/random_compat": "^2.0"
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "~2.7|~3.0",
+        "symfony/phpunit-bridge": "~2.8|~3.0",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 
     ],
     "require": {
-        "php": "^5.3 || ^7.0",
+        "php": "^5.6 || ^7.0",
         "paragonie/random_compat": "^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
I am targetting this branch, because dropping old versions of dependencies is considered major.

Closes #38 

## Changelog

Nothing about symfony in the changelog, I touched only a dev dependency

```markdown
### Removed
- PHP 5.3 through 5.5 support was removed
```

## Subject

Prepare for the next major release
