### PR TITLE
Adding "issuer" parameter

### DIFF
--- a/lib/GoogleAuthenticator.php
+++ b/lib/GoogleAuthenticator.php
@@ -88,6 +88,7 @@ class GoogleAuthenticator
 
         return $pinValue;
     }
+
     /**
      * @param string $user
      * @param string $hostname
@@ -100,9 +101,10 @@ class GoogleAuthenticator
     {
         $encoder = 'https://chart.googleapis.com/chart?chs=200x200&chld=M|0&cht=qr&chl=';
         $encoderURL = sprintf('%sotpauth://totp/%s@%s%%3Fsecret%%3D%s%%26issuer%%3D%s', $encoder, $user, $hostname, $secret, $issuer);
+
         return $encoderURL;
     }
-    
+ 
     /**
      * @return string
      */

--- a/lib/GoogleAuthenticator.php
+++ b/lib/GoogleAuthenticator.php
@@ -90,20 +90,21 @@ class GoogleAuthenticator
     }
 
     /**
-     * @param string $user
-     * @param string $hostname
-     * @param string $secret
-     *
+     * @param  string $user
+     * @param  string $hostname
+     * @param  string $secret
+     * @param  string $issue
+     * 
      * @return string
      */
-    public function getUrl($user, $hostname, $secret)
+    public function getUrl($user, $hostname, $secret, $issuer = '')
     {
-        $encoder = 'https://chart.googleapis.com/chart?chs=200x200&chld=M|0&cht=qr&chl=';
-        $encoderURL = sprintf('%sotpauth://totp/%s@%s%%3Fsecret%%3D%s', $encoder, $user, $hostname, $secret);
+        $encoder = "https://chart.googleapis.com/chart?chs=200x200&chld=M|0&cht=qr&chl=";
+        $encoderURL = sprintf("%sotpauth://totp/%s@%s%%3Fsecret%%3D%s%%26issuer%%3D%s", $encoder, $user, $hostname, $secret, $issuer);
 
         return $encoderURL;
     }
-
+    
     /**
      * @return string
      */

--- a/lib/GoogleAuthenticator.php
+++ b/lib/GoogleAuthenticator.php
@@ -90,17 +90,20 @@ class GoogleAuthenticator
     }
 
     /**
+     * NEXT_MAJOR: Add a new parameter called $issuer
+     *
      * @param string $user
      * @param string $hostname
      * @param string $secret
-     * @param string $issuer
      *
      * @return string
      */
-    public function getUrl($user, $hostname, $secret, $issuer = '')
+    public function getUrl($user, $hostname, $secret)
     {
+        $args = func_get_args();
         $encoder = 'https://chart.googleapis.com/chart?chs=200x200&chld=M|0&cht=qr&chl=';
-        $encoderURL = sprintf('%sotpauth://totp/%s@%s%%3Fsecret%%3D%s%%26issuer%%3D%s', $encoder, $user, $hostname, $secret, $issuer);
+        $urlString = '%sotpauth://totp/%s@%s%%3Fsecret%%3D%s%%26issuer%%3D%s';
+        $encoderURL = sprintf($urlString, $encoder, $user, $hostname, $secret, $args[3]);
 
         return $encoderURL;
     }

--- a/lib/GoogleAuthenticator.php
+++ b/lib/GoogleAuthenticator.php
@@ -104,7 +104,7 @@ class GoogleAuthenticator
 
         return $encoderURL;
     }
- 
+
     /**
      * @return string
      */

--- a/lib/GoogleAuthenticator.php
+++ b/lib/GoogleAuthenticator.php
@@ -93,7 +93,7 @@ class GoogleAuthenticator
      * @param  string $user
      * @param  string $hostname
      * @param  string $secret
-     * @param  string $issue
+     * @param  string $issuer
      * 
      * @return string
      */

--- a/lib/GoogleAuthenticator.php
+++ b/lib/GoogleAuthenticator.php
@@ -88,20 +88,18 @@ class GoogleAuthenticator
 
         return $pinValue;
     }
-
     /**
-     * @param  string $user
-     * @param  string $hostname
-     * @param  string $secret
-     * @param  string $issuer
-     * 
+     * @param string $user
+     * @param string $hostname
+     * @param string $secret
+     * @param string $issuer
+     *
      * @return string
      */
     public function getUrl($user, $hostname, $secret, $issuer = '')
     {
-        $encoder = "https://chart.googleapis.com/chart?chs=200x200&chld=M|0&cht=qr&chl=";
-        $encoderURL = sprintf("%sotpauth://totp/%s@%s%%3Fsecret%%3D%s%%26issuer%%3D%s", $encoder, $user, $hostname, $secret, $issuer);
-
+        $encoder = 'https://chart.googleapis.com/chart?chs=200x200&chld=M|0&cht=qr&chl=';
+        $encoderURL = sprintf('%sotpauth://totp/%s@%s%%3Fsecret%%3D%s%%26issuer%%3D%s', $encoder, $user, $hostname, $secret, $issuer);
         return $encoderURL;
     }
     

--- a/lib/GoogleAuthenticator.php
+++ b/lib/GoogleAuthenticator.php
@@ -90,7 +90,7 @@ class GoogleAuthenticator
     }
 
     /**
-     * NEXT_MAJOR: Add a new parameter called $issuer
+     * NEXT_MAJOR: Add a new parameter called $issuer.
      *
      * @param string $user
      * @param string $hostname

--- a/tests/GoogleAuthenticatorTest.php
+++ b/tests/GoogleAuthenticatorTest.php
@@ -42,9 +42,7 @@ class GoogleAuthenticatorTest extends \PHPUnit_Framework_TestCase
     public function testGetUrl()
     {
         $url = $this->helper->getUrl('foo', 'foobar.org', '3DHTQX4GCRKHGS55CJ', 'FooBar');
-
         $expected = 'https://chart.googleapis.com/chart?chs=200x200&chld=M|0&cht=qr&chl=otpauth://totp/foo@foobar.org%3Fsecret%3D3DHTQX4GCRKHGS55CJ%26issuer%3DFooBar';
-
         $this->assertEquals($expected, $url);
     }
 }

--- a/tests/GoogleAuthenticatorTest.php
+++ b/tests/GoogleAuthenticatorTest.php
@@ -43,7 +43,7 @@ class GoogleAuthenticatorTest extends \PHPUnit_Framework_TestCase
     {
         $url = $this->helper->getUrl('foo', 'foobar.org', '3DHTQX4GCRKHGS55CJ', 'FooBar');
 
-        $expected = "https://chart.googleapis.com/chart?chs=200x200&chld=M|0&cht=qr&chl=otpauth://totp/foo@foobar.org%3Fsecret%3D3DHTQX4GCRKHGS55CJ%26issuer%3DFooBar";
+        $expected = 'https://chart.googleapis.com/chart?chs=200x200&chld=M|0&cht=qr&chl=otpauth://totp/foo@foobar.org%3Fsecret%3D3DHTQX4GCRKHGS55CJ%26issuer%3DFooBar';
 
         $this->assertEquals($expected, $url);
     }

--- a/tests/GoogleAuthenticatorTest.php
+++ b/tests/GoogleAuthenticatorTest.php
@@ -41,9 +41,9 @@ class GoogleAuthenticatorTest extends \PHPUnit_Framework_TestCase
 
     public function testGetUrl()
     {
-        $url = $this->helper->getUrl('foo', 'foobar.org', '3DHTQX4GCRKHGS55CJ');
+        $url = $this->helper->getUrl('foo', 'foobar.org', '3DHTQX4GCRKHGS55CJ', 'FooBar');
 
-        $expected = 'https://chart.googleapis.com/chart?chs=200x200&chld=M|0&cht=qr&chl=otpauth://totp/foo@foobar.org%3Fsecret%3D3DHTQX4GCRKHGS55CJ';
+        $expected = "https://chart.googleapis.com/chart?chs=200x200&chld=M|0&cht=qr&chl=otpauth://totp/foo@foobar.org%3Fsecret%3D3DHTQX4GCRKHGS55CJ%26issuer%3DFooBar";
 
         $this->assertEquals($expected, $url);
     }


### PR DESCRIPTION
I am targetting this branch (1.x), because there's a strongly recommend parameter detailed here https://github.com/google/google-authenticator/wiki/Key-Uri-Format.

## Changelog

```markdown
### Changed
- Changed `getUrl` adding a new parameter : `$issuer`
```

## Subject

The issuer parameter is a string value indicating the provider or service this account is associated with, URL-encoded according to RFC 3986. If the issuer parameter is absent, issuer information may be taken from the issuer prefix of the label. If both issuer parameter and issuer label prefix are present, they should be equal.

Valid values corresponding to the label prefix examples above would be: issuer=Example, issuer=Provider1, and issuer=Big%20Corporation.

Older Google Authenticator implementations ignore the issuer parameter and rely upon the issuer label prefix to disambiguate accounts. Newer implementations will use the issuer parameter for internal disambiguation, it will not be displayed to the user. We recommend using both issuer label prefix and issuer parameter together to safely support both old and new Google Authenticator versions.
