### PR TITLE
Cleanup of GoogleAuthenticator

### DIFF
--- a/sample/example.php
+++ b/sample/example.php
@@ -13,7 +13,6 @@ include_once __DIR__.'/../src/Google/Authenticator/FixedBitNotation.php';
 include_once __DIR__.'/../src/Google/Authenticator/GoogleAuthenticator.php';
 
 $secret = 'XVQ2UIGO75XRUKJO';
-$time = floor(time() / 30);
 $code = '846474';
 
 $g = new \Google\Authenticator\GoogleAuthenticator();

--- a/src/FixedBitNotation.php
+++ b/src/FixedBitNotation.php
@@ -112,7 +112,7 @@ final class FixedBitNotation
      *
      * @return string
      */
-    public function encode($rawString)
+    public function encode($rawString): string
     {
         // Unpack string into an array of bytes
         $bytes = unpack('C*', $rawString);
@@ -195,7 +195,7 @@ final class FixedBitNotation
      *
      * @return string
      */
-    public function decode($encodedString, $caseSensitive = true, $strict = false)
+    public function decode($encodedString, $caseSensitive = true, $strict = false): string
     {
         if (!$encodedString || !is_string($encodedString)) {
             // Empty string, nothing to decode
@@ -238,11 +238,9 @@ final class FixedBitNotation
         for ($c = 0; $c <= $lastNotatedIndex; ++$c) {
             if (!isset($charmap[$encodedString[$c]]) && !$caseSensitive) {
                 // Encoded character was not found; try other case
-                if (isset($charmap[$cUpper
-                = strtoupper($encodedString[$c])])) {
+                if (isset($charmap[$cUpper = strtoupper($encodedString[$c])])) {
                     $charmap[$encodedString[$c]] = $charmap[$cUpper];
-                } elseif (isset($charmap[$cLower
-                = strtolower($encodedString[$c])])) {
+                } elseif (isset($charmap[$cLower = strtolower($encodedString[$c])])) {
                     $charmap[$encodedString[$c]] = $charmap[$cLower];
                 }
             }

--- a/src/FixedBitNotation.php
+++ b/src/FixedBitNotation.php
@@ -193,7 +193,7 @@ final class FixedBitNotation
      * @param bool   $strict        Returns null if $encodedString contains
      *                              an undecodable character
      *
-     * @return string|null
+     * @return string
      */
     public function decode($encodedString, $caseSensitive = true, $strict = false)
     {

--- a/src/FixedBitNotation.php
+++ b/src/FixedBitNotation.php
@@ -170,7 +170,7 @@ final class FixedBitNotation
             }
 
             // Read only the needed bits from this byte
-            $bits = $byte >> 8 - ($bitsRead + ($newBitCount));
+            $bits = $byte >> 8 - ($bitsRead + $newBitCount);
             $bits ^= $bits >> $newBitCount << $newBitCount;
             $bitsRead += $newBitCount;
 

--- a/src/FixedBitNotation.php
+++ b/src/FixedBitNotation.php
@@ -206,7 +206,6 @@ final class FixedBitNotation
         $bitsPerCharacter = $this->bitsPerCharacter;
         $radix = $this->radix;
         $rightPadFinalBits = $this->rightPadFinalBits;
-        $padFinalGroup = $this->padFinalGroup;
         $padCharacter = $this->padCharacter;
 
         // Get index of encoded characters

--- a/src/GoogleAuthenticator.php
+++ b/src/GoogleAuthenticator.php
@@ -64,8 +64,8 @@ final class GoogleAuthenticator
     }
 
     /**
-     * @param $secret
-     * @param $code
+     * @param string $secret
+     * @param string $code
      *
      * @return bool
      */
@@ -83,8 +83,8 @@ final class GoogleAuthenticator
     }
 
     /**
-     * @param $secret
-     * @param null $time
+     * @param string                $secret
+     * @param float|string|int|null $time
      *
      * @return string
      */

--- a/src/GoogleAuthenticator.php
+++ b/src/GoogleAuthenticator.php
@@ -90,7 +90,7 @@ final class GoogleAuthenticator
      */
     public function getCode($secret, $time = null): string
     {
-        if (!$time) {
+        if (null === $time) {
             $time = floor(time() / $this->codePeriod);
         }
 

--- a/src/GoogleAuthenticator.php
+++ b/src/GoogleAuthenticator.php
@@ -48,6 +48,11 @@ final class GoogleAuthenticator
     private $fixBitNotation;
 
     /**
+     * @var int
+     */
+    private $codePeriod = 30;
+
+    /**
      * @param int $passCodeLength
      * @param int $secretLength
      */
@@ -66,7 +71,8 @@ final class GoogleAuthenticator
      */
     public function checkCode($secret, $code)
     {
-        $time = floor(time() / 30);
+        $time = floor(time() / $this->codePeriod);
+
         for ($i = -1; $i <= 1; ++$i) {
             if (hash_equals($this->getCode($secret, $time + $i), $code)) {
                 return true;
@@ -85,7 +91,7 @@ final class GoogleAuthenticator
     public function getCode($secret, $time = null)
     {
         if (!$time) {
-            $time = floor(time() / 30);
+            $time = floor(time() / $this->codePeriod);
         }
 
         $base32 = new FixedBitNotation(5, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567', true, true);

--- a/src/GoogleAuthenticator.php
+++ b/src/GoogleAuthenticator.php
@@ -143,9 +143,6 @@ final class GoogleAuthenticator
      */
     private function hashToInt(string $bytes, int $start): int
     {
-        $input = substr($bytes, $start, strlen($bytes) - $start);
-        $val2 = unpack('N', substr($input, 0, 4));
-
-        return $val2[1];
+        return unpack('N', substr(substr($bytes, $start), 0, 4))[1];
     }
 }

--- a/src/GoogleAuthenticator.php
+++ b/src/GoogleAuthenticator.php
@@ -68,7 +68,7 @@ final class GoogleAuthenticator
     {
         $time = floor(time() / 30);
         for ($i = -1; $i <= 1; ++$i) {
-            if ($this->codesEqual($this->getCode($secret, $time + $i), $code)) {
+            if (hash_equals($this->getCode($secret, $time + $i), $code)) {
                 return true;
             }
         }
@@ -147,32 +147,5 @@ final class GoogleAuthenticator
         $val2 = unpack('N', substr($input, 0, 4));
 
         return $val2[1];
-    }
-
-    /**
-     * A constant time code comparison.
-     *
-     * @param string $known known code
-     * @param string $given code received from a user
-     *
-     * @return bool
-     *
-     * @see http://codereview.stackexchange.com/q/13512/6747
-     */
-    private function codesEqual(string $known, string $given): bool
-    {
-        if (strlen($given) !== strlen($known)) {
-            return false;
-        }
-
-        $res = 0;
-
-        $knownLen = strlen($known);
-
-        for ($i = 0; $i < $knownLen; ++$i) {
-            $res |= (ord($known[$i]) ^ ord($given[$i]));
-        }
-
-        return $res === 0;
     }
 }

--- a/src/GoogleAuthenticator.php
+++ b/src/GoogleAuthenticator.php
@@ -69,7 +69,7 @@ final class GoogleAuthenticator
      *
      * @return bool
      */
-    public function checkCode($secret, $code)
+    public function checkCode($secret, $code): bool
     {
         $time = floor(time() / $this->codePeriod);
 
@@ -88,7 +88,7 @@ final class GoogleAuthenticator
      *
      * @return string
      */
-    public function getCode($secret, $time = null)
+    public function getCode($secret, $time = null): string
     {
         if (!$time) {
             $time = floor(time() / $this->codePeriod);
@@ -119,7 +119,7 @@ final class GoogleAuthenticator
      *
      * @return string
      */
-    public function getUrl($user, $hostname, $secret)
+    public function getUrl($user, $hostname, $secret): string
     {
         $args = func_get_args();
         $encoder = 'https://chart.googleapis.com/chart?chs=200x200&chld=M|0&cht=qr&chl=';
@@ -132,7 +132,7 @@ final class GoogleAuthenticator
     /**
      * @return string
      */
-    public function generateSecret()
+    public function generateSecret(): string
     {
         $secret = random_bytes($this->secretLength);
 

--- a/tests/GoogleAuthenticatorTest.php
+++ b/tests/GoogleAuthenticatorTest.php
@@ -33,10 +33,35 @@ class GoogleAuthenticatorTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function testGetCode()
+    /**
+     * @dataProvider testCheckCodeData
+     */
+    public function testCheckCode($expectation, $inputDate)
     {
-        $this->assertTrue(
-            $this->helper->checkCode('3DHTQX4GCRKHGS55CJ', $this->helper->getCode('3DHTQX4GCRKHGS55CJ', strtotime('17/03/2012 22:17')))
+        $authenticator = new GoogleAuthenticator(6, 10, new \DateTime('2012-03-17 22:17:00'));
+        $this->assertSame(
+            $expectation,
+            $authenticator->checkCode('3DHTQX4GCRKHGS55CJ', $authenticator->getCode('3DHTQX4GCRKHGS55CJ', strtotime($inputDate) / 30))
+        );
+    }
+
+    /**
+     * all dates compare to the same date + or - the several seconds compared
+     * to 22:17:00 to verify if the code was perhaps the previous or next 30
+     * seconds. This ensures that slow entries or time delays are not causing
+     * problems.
+     *
+     * @return array
+     */
+    public static function testCheckCodeData(): array
+    {
+        return array(
+            array(false, '2012-03-17 22:16:29'),
+            array(true, '2012-03-17 22:16:30'),
+            array(true, '2012-03-17 22:17:00'),
+            array(true, '2012-03-17 22:17:30'),
+            array(false, '2012-03-17 22:18:00'),
+            array(false, 'this date cannot be resolved and results into false'),
         );
     }
 


### PR DESCRIPTION
This PR fixes the following things:
 - `hash_equals` as build-in php function to compare strings instead of a custom variant
 - A clearer `getUrl` method in preparation of a change require to make it more compatible with the google authenticator
 - php 7 notation shortcuts
 - php 7 return types
 - A new (optional) constructor argument indicating now, to prevent flaky tests when testing with codes
 - Fixed a broken unit-test/bug where false was considered as a non-argument for `getCode`
 - Cleaned up a private property that couldn't have possibly be used anywhere
 - Added more tests to prove the boundries of `checkCode`
 - Removed an unused variable from the example

In a followup PR I will work on making the actual functionality closer to what the google authenticator provides.