### PR TITLE
Resolving issue #135

### DIFF
--- a/src/GoogleAuthenticator.php
+++ b/src/GoogleAuthenticator.php
@@ -86,9 +86,9 @@ final class GoogleAuthenticator implements GoogleAuthenticatorInterface
         return $result > 0;
     }
 
-    final protected function setPeriod($period):bool
+    public function setCodePeriod(int $period):bool
     {
-        if (!(null === $period || intval($period) < 1 || intval($period) > 86400)) {
+        if ($period >= 1 && $period <= 86400)) {
             $this->codePeriod = $period;
             return true;
         }
@@ -96,7 +96,7 @@ final class GoogleAuthenticator implements GoogleAuthenticatorInterface
         return false;
     }
 
-    final protected function getPeriod():int
+    public function getCodePeriod():int
     {
         return $this->codePeriod;
     }

--- a/src/GoogleAuthenticator.php
+++ b/src/GoogleAuthenticator.php
@@ -86,6 +86,21 @@ final class GoogleAuthenticator implements GoogleAuthenticatorInterface
         return $result > 0;
     }
 
+    final protected function setPeriod($period):bool
+    {
+        if (!(null === $period || intval($period) < 1 || intval($period) > 86400)) {
+            $this->codePeriod = $period;
+            return true;
+        }
+
+        return false;
+    }
+
+    final protected function getPeriod():int
+    {
+        return $this->codePeriod;
+    }
+
     /**
      * NEXT_MAJOR: add the interface typehint to $time and remove deprecation.
      *

--- a/src/GoogleAuthenticator.php
+++ b/src/GoogleAuthenticator.php
@@ -88,7 +88,7 @@ final class GoogleAuthenticator implements GoogleAuthenticatorInterface
 
     public function setCodePeriod(int $period):bool
     {
-        if ($period >= 1 && $period <= 86400)) {
+        if ($period >= 1 && $period <= 86400) {
             $this->codePeriod = $period;
             return true;
         }

--- a/src/GoogleAuthenticator.php
+++ b/src/GoogleAuthenticator.php
@@ -88,12 +88,10 @@ final class GoogleAuthenticator implements GoogleAuthenticatorInterface
 
     public function setCodePeriod(int $period):bool
     {
-        if ($period >= 1 && $period <= 86400) {
-            $this->codePeriod = $period;
-            return true;
-        }
-
-        return false;
+        if ($period < 1 || $period > 86400) {
+		throw new InvalidArgumentException('setCodePeriod excepts a value between 1 and 86400 (1 day)');
+	}
+        $this->codePeriod = $period;
     }
 
     public function getCodePeriod():int

--- a/tests/GoogleAuthenticatorTest.php
+++ b/tests/GoogleAuthenticatorTest.php
@@ -124,22 +124,22 @@ class GoogleAuthenticatorTest extends \PHPUnit\Framework\TestCase
     public function testPeriodValid(): void
     {
         $authenticator = new GoogleAuthenticatorPrivateTest(8, 10, new \DateTime('2012-03-17 22:17:00'));
-	$this->assertSame(true, $authenticator->setPeriodTest(300));
-	$this->assertSame(300, $authenticator->getPeriodTest());
+        $this->assertSame(true, $authenticator->setPeriodTest(300));
+        $this->assertSame(300, $authenticator->getPeriodTest());
     }
 
     public function testPeriodInvalidZero(): void
     {
         $authenticator = new GoogleAuthenticatorPrivateTest(8, 10, new \DateTime('2012-03-17 22:17:00'));
-	$this->assertSame(false, $authenticator->setPeriodTest(0));
-	$this->assertSame(30, $authenticator->getPeriodTest());
+        $this->assertSame(false, $authenticator->setPeriodTest(0));
+        $this->assertSame(30, $authenticator->getPeriodTest());
     }
 
     public function testPeriodInvalidNull(): void
     {
         $authenticator = new GoogleAuthenticatorPrivateTest(8, 10, new \DateTime('2012-03-17 22:17:00'));
-	$this->assertSame(false, $authenticator->setPeriodTest(null));
-	$this->assertSame(30, $authenticator->getPeriodTest());
+        $this->assertSame(false, $authenticator->setPeriodTest(null));
+        $this->assertSame(30, $authenticator->getPeriodTest());
     }
 }
 

--- a/tests/GoogleAuthenticatorTest.php
+++ b/tests/GoogleAuthenticatorTest.php
@@ -121,37 +121,31 @@ class GoogleAuthenticatorTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testPeriodValid(): void
+    public function testCodePeriodValid(): void
     {
-        $authenticator = new GoogleAuthenticatorPrivateTest(8, 10, new \DateTime('2012-03-17 22:17:00'));
-        $this->assertTrue($authenticator->setPeriodTest(300));
-        $this->assertSame(300, $authenticator->getPeriodTest());
+        $authenticator = new GoogleAuthenticator(8, 10, new \DateTime('2012-03-17 22:17:00'));
+        $this->assertTrue($authenticator->setCodePeriod(300));
+        $this->assertSame(300, $authenticator->getCodePeriod());
     }
 
-    public function testPeriodInvalidZero(): void
+    public function testCodePeriodInvalidNegative(): void
     {
-        $authenticator = new GoogleAuthenticatorPrivateTest(8, 10, new \DateTime('2012-03-17 22:17:00'));
-        $this->assertFalse($authenticator->setPeriodTest(0));
-        $this->assertSame(30, $authenticator->getPeriodTest());
+        $authenticator = new GoogleAuthenticator(8, 10, new \DateTime('2012-03-17 22:17:00'));
+        $this->assertFalse($authenticator->setCodePeriod(-30));
+        $this->assertSame(30, $authenticator->getCodePeriod());
     }
 
-    public function testPeriodInvalidNull(): void
+    public function testCodePeriodInvalidMin(): void
     {
-        $authenticator = new GoogleAuthenticatorPrivateTest(8, 10, new \DateTime('2012-03-17 22:17:00'));
-        $this->assertFalse($authenticator->setPeriodTest(null));
-        $this->assertSame(30, $authenticator->getPeriodTest());
-    }
-}
-
-class GoogleAuthenticatorPrivateTest extends GoogleAuthenticator
-{
-    public function getPeriodTest()
-    {
-        return $this->getPeriod();
+        $authenticator = new GoogleAuthenticator(8, 10, new \DateTime('2012-03-17 22:17:00'));
+        $this->assertFalse($authenticator->setCodePeriod(0));
+        $this->assertSame(30, $authenticator->getCodePeriod());
     }
 
-    public function setPeriodTest($period)
+    public function testCodePeriodInvalidMax(): void
     {
-        return $this->setPeriod($period);
+        $authenticator = new GoogleAuthenticator(8, 10, new \DateTime('2012-03-17 22:17:00'));
+        $this->assertFalse($authenticator->setCodePeriod(86401));
+        $this->assertSame(30, $authenticator->getCodePeriod());
     }
 }

--- a/tests/GoogleAuthenticatorTest.php
+++ b/tests/GoogleAuthenticatorTest.php
@@ -124,21 +124,21 @@ class GoogleAuthenticatorTest extends \PHPUnit\Framework\TestCase
     public function testPeriodValid(): void
     {
         $authenticator = new GoogleAuthenticatorPrivateTest(8, 10, new \DateTime('2012-03-17 22:17:00'));
-        $this->assertSame(true, $authenticator->setPeriodTest(300));
+        $this->assertTrue($authenticator->setPeriodTest(300));
         $this->assertSame(300, $authenticator->getPeriodTest());
     }
 
     public function testPeriodInvalidZero(): void
     {
         $authenticator = new GoogleAuthenticatorPrivateTest(8, 10, new \DateTime('2012-03-17 22:17:00'));
-        $this->assertSame(false, $authenticator->setPeriodTest(0));
+        $this->assertFalse($authenticator->setPeriodTest(0));
         $this->assertSame(30, $authenticator->getPeriodTest());
     }
 
     public function testPeriodInvalidNull(): void
     {
         $authenticator = new GoogleAuthenticatorPrivateTest(8, 10, new \DateTime('2012-03-17 22:17:00'));
-        $this->assertSame(false, $authenticator->setPeriodTest(null));
+        $this->assertFalse($authenticator->setPeriodTest(null));
         $this->assertSame(30, $authenticator->getPeriodTest());
     }
 }

--- a/tests/GoogleAuthenticatorTest.php
+++ b/tests/GoogleAuthenticatorTest.php
@@ -120,4 +120,38 @@ class GoogleAuthenticatorTest extends \PHPUnit\Framework\TestCase
             $this->helper->getUrl('foo', 'foobar.org', '3DHTQX4GCRKHGS55CJ')
         );
     }
+
+    public function testPeriodValid(): void
+    {
+        $authenticator = new GoogleAuthenticatorPrivateTest(8, 10, new \DateTime('2012-03-17 22:17:00'));
+	$this->assertSame(true, $authenticator->setPeriodTest(300));
+	$this->assertSame(300, $authenticator->getPeriodTest());
+    }
+
+    public function testPeriodInvalidZero(): void
+    {
+        $authenticator = new GoogleAuthenticatorPrivateTest(8, 10, new \DateTime('2012-03-17 22:17:00'));
+	$this->assertSame(false, $authenticator->setPeriodTest(0));
+	$this->assertSame(30, $authenticator->getPeriodTest());
+    }
+
+    public function testPeriodInvalidNull(): void
+    {
+        $authenticator = new GoogleAuthenticatorPrivateTest(8, 10, new \DateTime('2012-03-17 22:17:00'));
+	$this->assertSame(false, $authenticator->setPeriodTest(null));
+	$this->assertSame(30, $authenticator->getPeriodTest());
+    }
+}
+
+class GoogleAuthenticatorPrivateTest extends GoogleAuthenticator
+{
+    public function getPeriodTest()
+    {
+        return $this->getPeriod();
+    }
+
+    public function setPeriodTest($period)
+    {
+        return $this->setPeriod($period);
+    }
 }

--- a/tests/GoogleAuthenticatorTest.php
+++ b/tests/GoogleAuthenticatorTest.php
@@ -22,6 +22,24 @@ class GoogleAuthenticatorTest extends \PHPUnit\Framework\TestCase
      */
     protected $helper;
 
+    /**
+     * Asserts that the given callback throws the given exception.
+     *
+     * @param string $expectClass The name of the expected exception class
+     * @param callable $callback A callback which should throw the exception
+     */
+    protected function assertException(string $expectClass, callable $callback)
+    {
+        try {
+            $callback();
+        } catch (\Throwable $exception) {
+            $this->assertInstanceOf($expectClass, $exception, 'An invalid exception was thrown');
+            return;
+        }
+
+        $this->fail('No exception was thrown');
+    }
+
     public function setUp(): void
     {
         $this->helper = new GoogleAuthenticator();
@@ -124,28 +142,28 @@ class GoogleAuthenticatorTest extends \PHPUnit\Framework\TestCase
     public function testCodePeriodValid(): void
     {
         $authenticator = new GoogleAuthenticator(8, 10, new \DateTime('2012-03-17 22:17:00'));
-        $this->assertTrue($authenticator->setCodePeriod(300));
+        $this->assertFalse($authenticator->setCodePeriod(300));
         $this->assertSame(300, $authenticator->getCodePeriod());
     }
 
     public function testCodePeriodInvalidNegative(): void
     {
         $authenticator = new GoogleAuthenticator(8, 10, new \DateTime('2012-03-17 22:17:00'));
-        $this->assertFalse($authenticator->setCodePeriod(-30));
+        $this->assertException('InvalidArgumentException', function() { $authenticator->setCodePeriod(-30); });
         $this->assertSame(30, $authenticator->getCodePeriod());
     }
 
     public function testCodePeriodInvalidMin(): void
     {
         $authenticator = new GoogleAuthenticator(8, 10, new \DateTime('2012-03-17 22:17:00'));
-        $this->assertFalse($authenticator->setCodePeriod(0));
+        $this->assertException('InvalidArgumentException', function() { $authenticator->setCodePeriod(0); });
         $this->assertSame(30, $authenticator->getCodePeriod());
     }
 
     public function testCodePeriodInvalidMax(): void
     {
         $authenticator = new GoogleAuthenticator(8, 10, new \DateTime('2012-03-17 22:17:00'));
-        $this->assertFalse($authenticator->setCodePeriod(86401));
+        $this->assertException('InvalidArgumentException', function() { $authenticator->setCodePeriod(86401); });
         $this->assertSame(30, $authenticator->getCodePeriod());
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Allow codePeriod to be set by inherited classes

<!-- Describe your Pull Request content here -->
This is to resolve #135 which hasn't had a PR yet and I was already making some other changes.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/GoogleAuthenticator/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it's the current branch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #135 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/GoogleAuthenticator/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `GoogleAuthenticator->setPeriod()` and `GoogleAuthenticator->getPeriod()` to allow inherited classes the chance to change the default 30 second period

### Changed

### Deprecated

### Removed

### Fixed

### Security
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
