### PR TITLE
 prevent a float being passed to str_repeat

### DIFF
--- a/src/FixedBitNotation.php
+++ b/src/FixedBitNotation.php
@@ -154,9 +154,9 @@ final class FixedBitNotation
                         // $bitsPerCharacter and 8, divided by 8
                         $lcmMap = [1 => 1, 2 => 1, 3 => 3, 4 => 1, 5 => 5, 6 => 3, 7 => 7, 8 => 1];
                         $bytesPerGroup = $lcmMap[$bitsPerCharacter];
-                        $pads = $bytesPerGroup * 8 / $bitsPerCharacter
+                        $pads = (int) ($bytesPerGroup * 8 / $bitsPerCharacter
                         - ceil((\strlen($rawString) % $bytesPerGroup)
-                        * 8 / $bitsPerCharacter);
+                        * 8 / $bitsPerCharacter));
                         $encodedString .= str_repeat($padCharacter[0], $pads);
                     }
 

--- a/tests/FixedBitNotationTest.php
+++ b/tests/FixedBitNotationTest.php
@@ -54,6 +54,18 @@ class FixedBitNotationTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test with padding.
+     *
+     * @dataProvider decodeIsSameAsEncode
+     */
+    public function testDecodeIsSameAsEncodeWithPadding($input): void
+    {
+        $bits = new FixedBitNotation(5, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567', true, true);
+
+        $this->assertSame((string) $input, $bits->decode($bits->encode($input)));
+    }
+
+    /**
      * Every single value in here should be equal to the returned string value.
      *
      * @return array


### PR DESCRIPTION
## Hot fix
This pull request will prevent php type casting a float when a integer is required. Resulting in the following fatal error.

PHP Fatal error:  Uncaught TypeError: str_repeat() expects parameter 2 to be integer, float given...

This may happen when a custom secret is generated that is not 10 characters long. 

I am targeting this branch because it is the current default.

## Changelog

```
### Fixed
prevent php casting to an incorrect type which will cause a fatal error
```